### PR TITLE
fix for linux case-sensitivity

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #endif
 
 #include <tier0/dbg.h>
-#include <Color.h>
+#include <color.h>
 #include <cstdio>
 #include <GarrysMod/Lua/Interface.h>
 #include <Platform.hpp>


### PR DESCRIPTION
The compiler gets a little unhappy at `<Color.h>` on linux due to case-sensitivity.  I believe @Kitsumi also had similar issues during testing.