### PR TITLE
fix stack underflow

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,14 +162,6 @@ public:
 		if (LUA->PCall(8, 1, 0) != 0)
 		{
 			Warning("[EngineSpew error] %s\n", LUA->GetString());
-			LUA->Pop(3);
-			inspew = false;
-		}
-
-		if (LUA->IsType(-1, GarrysMod::Lua::Type::BOOL) && LUA->GetBool())
-		{
-			LUA->Pop(3);
-			inspew = false;
 		}
 
 		LUA->Pop(3);


### PR DESCRIPTION
woulda found this way sooner had I understood binary modules

old code permits popping more than 3 items from the lua stack, which causes a crash in certain edge cases